### PR TITLE
feat: add tag release and conclusion

### DIFF
--- a/.github/workflows/build_test_and_deploy.yml
+++ b/.github/workflows/build_test_and_deploy.yml
@@ -35,6 +35,7 @@ jobs:
           wait-on: http://localhost:3001
   deploy_for_production:
     runs-on: ubuntu-20.04
+    if: ${{ github.event_name == 'push' }}
     needs: [build_and_test]
     steps:
       - uses: actions/checkout@v2
@@ -44,3 +45,51 @@ jobs:
           heroku_app_name: "blogapp-for-heroku"
           heroku_email: ${{secrets.EMAIL_ADDRESS}}
           rollbackonhealthcheckfailed: true
+  tag_release:
+    runs-on: ubuntu-20.04
+    needs: [deploy_for_production]
+    if: ${{ github.event_name == 'push' && !contains(join(github.event.commits.*.message, ' '), '#skip') }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          WITH_V: true
+  conclusion:
+    runs-on: ubuntu-20.04
+    needs: [tag_release]
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - name: Test Success
+        uses: rjstone/discord-webhook-notify@v1
+        if: success()
+        with:
+          severity: info
+          username: Automated Deployment
+          details: Deployment successful 🎉
+          color: '#27b376'
+          avatarUrl: https://images.emojiterra.com/google/android-11/512px/1f680.png
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Test Failure
+        uses: rjstone/discord-webhook-notify@v1
+        if: failure()
+        with:
+          severity: error
+          username: Automated Deployment
+          color: '#bf212f'
+          details: Deployment failed ☠️
+          avatarUrl: https://images.emojiterra.com/google/android-11/512px/1f680.png
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Test Cancelled
+        uses: rjstone/discord-webhook-notify@v1
+        if: cancelled()
+        with:
+          severity: warn
+          username: Automated Deployment
+          details: Deployment cancelled 🚫
+          avatarUrl: https://images.emojiterra.com/google/android-11/512px/1f680.png
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
- Add `tag_release` and `conclusion` to `./github/workflows/build_test_and_deploy.yml`

- `tag_release` generates a new version every time **if** deployment has succeeded.
- `conclusion` makes a notification to Discord about the deployment details.